### PR TITLE
Updated dialog warning handling for getExpiryTime

### DIFF
--- a/patched-vscode/extensions/sagemaker-extension/src/extension.ts
+++ b/patched-vscode/extensions/sagemaker-extension/src/extension.ts
@@ -71,19 +71,21 @@ function initialize(sagemakerCookie: SagemakerCookie) {
     const currentTime = Date.now();
     const timeToExpiry = getExpiryTime(sagemakerCookie) - currentTime;
 
-    if (timeToExpiry <= 0) {
-        signInError(sagemakerCookie);
-    } else if (timeToExpiry >= FIFTEEN_MINUTES_INTERVAL_MILLIS) {
-        const warningTime = timeToExpiry - FIFTEEN_MINUTES_INTERVAL_MILLIS;
-        setTimeout(() => {
-            showWarningDialog();
-        }, warningTime);
-    } else {
-        // If less than or equal to 15 minutes left, set a timer for the remaining time
-        const warningTime = timeToExpiry % FIVE_MINUTES_INTERVAL_MILLIS;
-        setTimeout(() => {
-            showWarningDialog();
-        }, warningTime);
+    if (getExpiryTime(sagemakerCookie) !== -1) {
+        if (timeToExpiry <= 0) {
+            signInError(sagemakerCookie);
+        } else if (timeToExpiry >= FIFTEEN_MINUTES_INTERVAL_MILLIS) {
+            const warningTime = timeToExpiry - FIFTEEN_MINUTES_INTERVAL_MILLIS;
+            setTimeout(() => {
+                showWarningDialog();
+            }, warningTime);
+        } else {
+            // If less than or equal to 15 minutes left, set a timer for the remaining time
+            const warningTime = timeToExpiry % FIVE_MINUTES_INTERVAL_MILLIS;
+            setTimeout(() => {
+                showWarningDialog();
+            }, warningTime);
+        }
     }
 }
 

--- a/patched-vscode/extensions/sagemaker-extension/src/extension.ts
+++ b/patched-vscode/extensions/sagemaker-extension/src/extension.ts
@@ -45,7 +45,7 @@ function showWarningDialog() {
                         }
                     });
 
-            } else {
+            } else if (getExpiryTime(sagemakerCookie) == -1 || remainingTime <=0) {
                 // this means expiryTime cookie is either invalid or <0
                 signInError(sagemakerCookie);
             }

--- a/patches/sagemaker-extension.diff
+++ b/patches/sagemaker-extension.diff
@@ -2,7 +2,7 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-extension/src/extension
 ===================================================================
 --- /dev/null
 +++ sagemaker-code-editor/vscode/extensions/sagemaker-extension/src/extension.ts
-@@ -0,0 +1,137 @@
+@@ -0,0 +1,139 @@
 +import * as vscode from 'vscode';
 +import * as fs from 'fs';
 +import { SessionWarning } from "./sessionWarning";
@@ -76,19 +76,21 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-extension/src/extension
 +    const currentTime = Date.now();
 +    const timeToExpiry = getExpiryTime(sagemakerCookie) - currentTime;
 +
-+    if (timeToExpiry <= 0) {
-+        signInError(sagemakerCookie);
-+    } else if (timeToExpiry >= FIFTEEN_MINUTES_INTERVAL_MILLIS) {
-+        const warningTime = timeToExpiry - FIFTEEN_MINUTES_INTERVAL_MILLIS;
-+        setTimeout(() => {
-+            showWarningDialog();
-+        }, warningTime);
-+    } else {
-+        // If less than or equal to 15 minutes left, set a timer for the remaining time
-+        const warningTime = timeToExpiry % FIVE_MINUTES_INTERVAL_MILLIS;
-+        setTimeout(() => {
-+            showWarningDialog();
-+        }, warningTime);
++    if (getExpiryTime(sagemakerCookie) !== -1) {
++        if (timeToExpiry <= 0) {
++            signInError(sagemakerCookie);
++        } else if (timeToExpiry >= FIFTEEN_MINUTES_INTERVAL_MILLIS) {
++            const warningTime = timeToExpiry - FIFTEEN_MINUTES_INTERVAL_MILLIS;
++            setTimeout(() => {
++                showWarningDialog();
++            }, warningTime);
++        } else {
++            // If less than or equal to 15 minutes left, set a timer for the remaining time
++            const warningTime = timeToExpiry % FIVE_MINUTES_INTERVAL_MILLIS;
++            setTimeout(() => {
++                showWarningDialog();
++            }, warningTime);
++        }
 +    }
 +}
 +

--- a/patches/sagemaker-extension.diff
+++ b/patches/sagemaker-extension.diff
@@ -50,7 +50,7 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-extension/src/extension
 +                        }
 +                    });
 +
-+            } else {
++            } else if (getExpiryTime(sagemakerCookie) == -1 || remainingTime <=0) {
 +                // this means expiryTime cookie is either invalid or <0
 +                signInError(sagemakerCookie);
 +            }


### PR DESCRIPTION
*Issue #, if available:* Addresses issue where in local environment, a false "Sign In" notification is shown due to the `else` condition handling 

Originally, `getExpiryTime` has a numeric value <= 0 or `-1` (the original value passed as null, see: https://github.com/aws/sagemaker-code-editor/blob/e25a34b908e4ba3ff063095bde8a9966b05825e0/patched-vscode/extensions/sagemaker-extension/src/constant.ts#L70

The conditional for the `signInError` triggered when the value of `getExpiryTime` <=0, which was the case as an empty `expiryTime` cookie still lead to `expiryTime` being populated as `-1`.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
