### PR TITLE
Fix base-path reference

### DIFF
--- a/patched-vscode/src/vs/server/node/webClientServer.ts
+++ b/patched-vscode/src/vs/server/node/webClientServer.ts
@@ -306,7 +306,7 @@ export class WebClientServer {
 			scopes: [['user:email'], ['repo']]
 		} : undefined;
 
-		const basePath: string = this._environmentService.args['server-base-path'] || "/"
+		const basePath: string = this._environmentService.args['base-path'] || "/"
 		const base = relativeRoot(basePath)
 		const vscodeBase = relativePath(basePath)
 

--- a/patches/base-path.diff
+++ b/patches/base-path.diff
@@ -137,7 +137,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  			scopes: [['user:email'], ['repo']]
  		} : undefined;
 
-+		const basePath: string = this._environmentService.args['server-base-path'] || "/"
++		const basePath: string = this._environmentService.args['base-path'] || "/"
 +		const base = relativeRoot(basePath)
 +		const vscodeBase = relativePath(basePath)
 +


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There was a bug where the static assets were unable to load if CE was being served from a custom root endpoint such as `/codeeditor/default`. 

This was caused by a reference to the wrong base-path variable name. It was `server-base-path` when it should of have been `base-path`

- [x] These changes will not break the local running of CE (outside SM). Verified by running the application locally. 

*Testing*
I've tested locally and on SM Studio by ensuring the static assets were being loaded successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
