### PR TITLE
Generalize post install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Whenever we create a new branch with `vscode` pointing to a specific commit, thi
 
 To properly patch, please run script:
 
-`sh ./scripts/install.sh`
+```bash
+sh ./scripts/install.sh
+```
 
 This script will:
 
@@ -20,6 +22,13 @@ This script will:
 - runs `./scripts/postinstall.sh` that will comment out 2 breaking `git config` lines from `./vscode/build/npm/postinstall.js`
 - runs `./scripts/copy-resource.sh` that will copy patched version of code - oss from `./vscode` into `./patched-vscode` folder along with icon(s) and svg(s) from `./resources` folder
 - runs `yarn install` and downloads built in extensions on patched submodule
+
+Adding the `--verbose` flag will provide additional information for the `yarn install` command.
+
+Example: 
+```bash
+sh ./scripts/install.sh --verbose
+```
 
 ## Local Setup
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+VERBOSE_FLAG=$([[ "$1" == "--verbose" ]] && echo "--verbose" || echo "")
+
 # set +e to prevent quilt from exiting when no patches popped
 set +e
 
@@ -41,5 +43,5 @@ rm -rf "${PROJ_ROOT}/vscode/node_modules"
 
 # Build the project
 printf "\n======== Building project in ${PROJ_ROOT}/vscode ========\n"
-yarn --cwd "${PROJ_ROOT}/vscode" install --pure-lockfile --verbose
+yarn --cwd "${PROJ_ROOT}/vscode" install --pure-lockfile ${VERBOSE_FLAG}
 yarn --cwd "${PROJ_ROOT}/vscode" download-builtin-extensions

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -15,6 +15,9 @@ if [ ! -f "$POSTINSTALL_JS_PATH" ]; then
     exit 1
 fi
 
+# set +e to prevent script from exiting when not on macOS
+set +e
+
 # Check if on macOS
 system_profiler SPSoftwareDataType
 

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -15,8 +15,16 @@ if [ ! -f "$POSTINSTALL_JS_PATH" ]; then
     exit 1
 fi
 
-# Use sed to comment out the specific lines
-sed -i '' '/cp\.execSync('"'"'git config pull\.rebase merges'"'"');/s/^/\/\/ /' "$POSTINSTALL_JS_PATH"
-sed -i '' '/cp\.execSync('"'"'git config blame\.ignoreRevsFile \.git-blame-ignore'"'"');/s/^/\/\/ /' "$POSTINSTALL_JS_PATH"
+# Check if on macOS
+system_profiler SPSoftwareDataType
+
+# Run with different arguments depending on the OS
+if [ $? -eq 0 ]; then
+    # Use sed to comment out the specific lines
+    sed -i '' '/cp\.execSync('"'"'git config .*);/s/^/\/\/ /' "$POSTINSTALL_JS_PATH"
+else
+    # Use sed to comment out the specific lines
+    sed -i '/cp\.execSync('"'"'git config .*);/s/^/\/\/ /' "$POSTINSTALL_JS_PATH"
+fi
 
 echo "Specified git config lines have been commented out in $POSTINSTALL_JS_PATH."


### PR DESCRIPTION
*Issue #, if available:*
The sed command in the `postinstall.sh` script would fail on Linux OS, but work fine on macOS


*Description of changes:*
Added a check for macOS that runs with different arguments on Linux vs macOS.
Also removed the verbose flag from the `yarn install` command and added an argument.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
