### PR TITLE
Generalize install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ This script will:
 - runs `./scripts/copy-resource.sh` that will copy patched version of code - oss from `./vscode` into `./patched-vscode` folder along with icon(s) and svg(s) from `./resources` folder
 - runs `yarn install` and downloads built in extensions on patched submodule
 
+Usage:
+```bash
+Usage: install.sh [-t <VERSION>] [-v] [-h]
+
+Otions:
+  -t <VERSION>    Create a tarball with the specified version
+  -v              Enable verbose output
+  -h              Show this help message
+```
+
 ## Local Setup
 
 - Install Prerequisite tools described [here](https://web.archive.org/web/20240711074020/https://github.com/microsoft/vscode/wiki/How-to-Contribute#prerequisites) for your operating system.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -79,7 +79,7 @@ fi
 
 # Copy resources
 printf "\n======== Copy resources ========\n"
-sh ${PROJ_ROOT}/scripts/copy-resources.sh
+${PROJ_ROOT}/scripts/copy-resources.sh
 
 # Delete node_modules to prevent node-gyp build error
 printf "\n======== Deleting vscode/node_modules ========\n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,25 +1,26 @@
 #!/bin/bash
 
-while getopts "v:" opt; do
-  case $opt in
-    v) version="$OPTARG"
-    ;;
-    \?) echo "Invalid option -$OPTARG" >&2
-    exit 1
-    ;;
-  esac
+usage() {
+  printf """
+Usage: $0 [-t <VERSION>] [-v] [-h]
 
-  case $OPTARG in
-    -*) echo "Option $opt needs a valid argument"
-    exit 1
-    ;;
+Otions:
+  -t <VERSION>    Create a tarball with the specified version
+  -v              Enable verbose output
+  -h              Show this help message
+"""
+}
+
+while getopts "t:hv" opt; do
+  case $opt in
+    t)  version="$OPTARG"
+        CREATE_TARBALL=true ;;
+    v)  VERBOSE_ARG="--verbose" ;;
+    h)  usage; exit 0 ;;
+    :)  printf "Error: -${OPTARG} requires an argument.\n" >&2; exit 1 ;;
+    ?) usage; exit 1 ;;
   esac
 done
-
-if [[ -z $version ]]; then
- echo "Please provide version using '-v'";
- exit 1
-fi
 
 VERSION=$version
 
@@ -48,11 +49,11 @@ git submodule update --init
 # Apply patches
 printf "\n======== Applying patches ========\n"
 {
-    quilt push -a --leave-rejects --color=auto 
+  quilt push -a --leave-rejects --color=auto 
 } || {
-        printf "\nPatching error, review logs!\n"
-        find ./vscode -name "*.rej"
-        exit 1
+  printf "\nPatching error, review logs!\n"
+  find ./vscode -name "*.rej"
+  exit 1
 }
 
 
@@ -68,9 +69,12 @@ cd ${PROJ_ROOT}
 printf "\n======== Comment out breaking git config lines in postinstall.js ========\n"
 sh ${PROJ_ROOT}/scripts/postinstall.sh
 
-# Build tarball for conda feedstock from vscode dir
-printf "\n======== Build Tarball for Conda Feedstock ========\n"
-bash ${PROJ_ROOT}/scripts/create_code_editor_tarball.sh -v ${VERSION}
+# Create tarball
+if [ "$CREATE_TARBALL" = true ]; then
+  # Build tarball for conda feedstock from vscode dir
+  printf "\n======== Build Tarball for Conda Feedstock ========\n"
+  bash ${PROJ_ROOT}/scripts/create_code_editor_tarball.sh -v ${VERSION}
+fi
 
 # Copy resources
 printf "\n======== Copy resources ========\n"
@@ -82,5 +86,5 @@ rm -rf "${PROJ_ROOT}/vscode/node_modules"
 
 # Build the project
 printf "\n======== Building project in ${PROJ_ROOT}/vscode ========\n"
-yarn --cwd "${PROJ_ROOT}/vscode" install --pure-lockfile --verbose
+yarn --cwd "${PROJ_ROOT}/vscode" install --pure-lockfile ${VERBOSE_ARG}
 yarn --cwd "${PROJ_ROOT}/vscode" download-builtin-extensions

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -74,6 +74,7 @@ if [ "$CREATE_TARBALL" = true ]; then
   # Build tarball for conda feedstock from vscode dir
   printf "\n======== Build Tarball for Conda Feedstock ========\n"
   bash ${PROJ_ROOT}/scripts/create_code_editor_tarball.sh -v ${VERSION}
+  exit 0
 fi
 
 # Copy resources

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -15,7 +15,19 @@ if [ ! -f "$POSTINSTALL_JS_PATH" ]; then
     exit 1
 fi
 
-# Use sed to comment out the specific lines
-sed -i '' '/cp\.execSync('"'"'git config .*);/s/^/\/\/ /' "$POSTINSTALL_JS_PATH"
+# set +e to prevent script from exiting when not on macOS
+set +e
+
+# Check if on macOS
+system_profiler SPSoftwareDataType
+
+# Run with different arguments depending on the OS
+if [ $? -eq 0 ]; then
+    # Use sed to comment out the specific lines
+    sed -i '' '/cp\.execSync('"'"'git config .*);/s/^/\/\/ /' "$POSTINSTALL_JS_PATH"
+else
+    # Use sed to comment out the specific lines
+    sed -i '/cp\.execSync('"'"'git config .*);/s/^/\/\/ /' "$POSTINSTALL_JS_PATH"
+fi
 
 echo "Specified git config lines have been commented out in $POSTINSTALL_JS_PATH."


### PR DESCRIPTION
*Description of changes:*
I changed the install script so creating the tarball is optional. The `install.sh` script exits early when creating a tarball.

The verbose output is now off by default as well. The postinstall script is now compatible with both macOS and clouddesk/Linux.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
