### PR TITLE
Add GitHub action for testing PRs

### DIFF
--- a/.github/workflows/codebuild-ci.yml
+++ b/.github/workflows/codebuild-ci.yml
@@ -1,6 +1,4 @@
-# This is a basic workflow to help you get started with Actions
-
-name: Pull Request
+name: Pull Request Checks
 
 # Controls when the workflow will run
 on:
@@ -14,22 +12,16 @@ on:
 permissions:
   id-token: write # This is required for requesting the JWT
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
-        # You may pin to the exact commit or the version.
-        # uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          # AWS Region, e.g. us-east-2
           aws-region: us-east-1
           # The Amazon Resource Name (ARN) of the role to assume. Use the provided credentials to assume an IAM role and configure the Actions environment with the assumed role credentials rather than with the provided credentials.
           role-to-assume: ${{ secrets.AWS_CODE_BUILD_ROLE_ARN }} # optional
-          # Role duration in seconds. Default is one hour.
-          # role-duration-seconds: # optional
           audience: sts.amazonaws.com
       - name: Run CodeBuild
         uses: aws-actions/aws-codebuild-run-build@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Pull Request
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on pull request events but only for the "main" branch
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        # You may pin to the exact commit or the version.
+        # uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          # AWS Region, e.g. us-east-2
+          aws-region: us-east-1
+          # The Amazon Resource Name (ARN) of the role to assume. Use the provided credentials to assume an IAM role and configure the Actions environment with the assumed role credentials rather than with the provided credentials.
+          role-to-assume: ${{ secrets.AWS_CODE_BUILD_ROLE_ARN }} # optional
+          # Role duration in seconds. Default is one hour.
+          # role-duration-seconds: # optional
+          audience: sts.amazonaws.com
+      - name: Run CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: CodeEditorTesting
+          source-version-override: 'refs/pull/${{ github.event.pull_request.number }}/head^{${{ github.event.pull_request.head.sha }}}'
+          


### PR DESCRIPTION
Description of changes:
This adds a github action that runs the tests against the code in the PR.

Testing
I tested this action my own fork of the repository

Notes

The tests will currently fail because they have bugs.
The arn of the code build account still has to be added as a repository secret.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.