### PR TITLE
Add Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,101 @@
+name: Automated Release
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on updates to the "main" branch which include a version tag
+  push:
+    tags:        
+      - '**'           # Push events to every tag including hierarchical tags like v1.0/beta
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  branch-name: automated-dev-update
+  
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  check-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check tag is version tag
+        id: check
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            REF="${{ github.ref }}"
+            VERSION="${REF##refs/tags/v}"
+            echo "Tag starts with 'v'."
+            echo "Version: ${VERSION}"
+            echo "Continuing..."
+            echo "version=${VERSION}" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "The tag doesn't start with 'v'. To release a new version, the tag must start with 'v'"
+            exit 1
+          fi
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      
+  release:
+    environment: release
+    runs-on: ubuntu-latest
+    needs: [check-tag]
+    container:
+      image: node:20
+    steps:
+      - name: Checkout the main branch
+        uses: actions/checkout@v4
+      - name: Install Dependencies
+        run: |
+          apt-get update
+          apt-get install -y build-essential g++ libx11-dev libxkbfile-dev libsecret-1-dev libkrb5-dev python-is-python3 quilt
+      - name: Build Tarball
+        id: build
+        run: |
+          git config --global --add safe.directory /__w/sagemaker-code-editor/sagemaker-code-editor
+          sh ./scripts/install.sh -t ${{ needs.check-tag.outputs.version }}
+          
+          TARBALL_NAME="code-editor${{ needs.check-tag.outputs.version }}.tar.gz"
+          echo "tarball_name=${TARBALL_NAME}" >> $GITHUB_OUTPUT
+          
+          SHA256_HASH=$(sha256sum ${TARBALL_NAME} | awk '{ print $1 }')
+          echo "sha256_hash=${SHA256_HASH}" >> $GITHUB_OUTPUT
+      - name: Publish Release
+        id: publish
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Code Editor ${{ needs.check-tag.outputs.version }}
+          tag_name: v${{ needs.check-tag.outputs.version }}
+          files: |
+            ${{ steps.build.outputs.tarball_name }}
+    outputs:
+      sha256_hash: ${{ steps.build.outputs.sha256_hash }}
+      assets: ${{ steps.publish.outputs.assets }}
+
+  update-feedstock-files:
+    runs-on: ubuntu-latest
+    needs: [check-tag, release]
+    steps:
+      - name: Clone the feedstock repository
+        uses: actions/checkout@v4
+        with:
+          repository: 'conda-forge/sagemaker-code-editor-feedstock'
+          ref: 'dev'
+      - name: Create a new dev branch
+        run: |
+          git checkout -b ${{ env.branch-name }}
+      - name: Update meta.yaml
+        run: |
+          VERSION=${{ needs.check-tag.outputs.version }}
+          sed -i "s/{% set version = \".*\" %}/{% set version = \"$VERSION\" %}/" recipe/meta.yaml
+
+          URL="${{ fromJSON(needs.release.outputs.assets)[0].browser_download_url }}"
+          sed -i "s|url: .*\.tar\.gz|url: $URL|" recipe/meta.yaml
+
+          SHA256=${{ needs.release.outputs.sha256_hash }}
+          sed -i "s|sha256: [0-9a-f]*|sha256: $SHA256|" recipe/meta.yaml
+      - name: Run diff
+        run: git diff


### PR DESCRIPTION
Add a workflow to build and publish a release with tarball of Code Editor.

This workflow is triggered whenever a tag is pushed that begins with `v` (ex. `v10.0.1` or `v10.0.1-dev`).
Manual approval is required for the tarball to be created and published as a release. 

**Testing**
An example of a successful run of a workflow extremely similar to this: https://github.com/aws-donocl/sagemaker-code-editor/actions/runs/10564424011

**Notes**
This demonstrates updating the meta.yaml file in sagemaker-code-editor-feedstock. However, the feedstock repository does not get actually updated by this workflow, due to time constraints. This was decided together with @aws-zuoyuan.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
