### PR TITLE
feat:enable deeplink for eks notebook

### DIFF
--- a/patched-vscode/extensions/sagemaker-open-notebook-extension/src/extension.ts
+++ b/patched-vscode/extensions/sagemaker-open-notebook-extension/src/extension.ts
@@ -45,6 +45,15 @@ function processNotebookContent(content: string, clusterId: string, region: stri
             ];
             cell.cell_type = "code";
         }
+
+        if (cell.metadata && 
+            cell.metadata.jumpStartAlterations && 
+            cell.metadata.jumpStartAlterations.includes('clusterName')) {
+            cell.source = [
+                `!hyperpod connect-cluster --cluster-name ${clusterId}`
+            ]
+            cell.cell_type = "code";
+        }
         return cell;
     });
     return JSON.stringify(notebook, null, 2);

--- a/patches/sagemaker-open-notebook-extension.patch
+++ b/patches/sagemaker-open-notebook-extension.patch
@@ -162,7 +162,7 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-open-notebook-extension
 ===================================================================
 --- /dev/null
 +++ sagemaker-code-editor/vscode/extensions/sagemaker-open-notebook-extension/src/extension.ts
-@@ -0,0 +1,80 @@
+@@ -0,0 +1,89 @@
 +
 +import * as vscode from 'vscode';
 +import * as https from 'https';
@@ -208,6 +208,15 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-open-notebook-extension
 +                "%%bash\n",
 +                `aws ssm start-session --target sagemaker-cluster:${clusterId} --region ${region}`
 +            ];
++            cell.cell_type = "code";
++        }
++
++        if (cell.metadata && 
++            cell.metadata.jumpStartAlterations && 
++            cell.metadata.jumpStartAlterations.includes('clusterName')) {
++            cell.source = [
++                `!hyperpod connect-cluster --cluster-name ${clusterId}`
++            ]
 +            cell.cell_type = "code";
 +        }
 +        return cell;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR enables the deeplink for eks sample notebook so that the command can replace the cluster name correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

The change has been tested locally and also in studio environment