### PR TITLE
feat: Add tests for SageMaker UI Dark Theme extension

### DIFF
--- a/patched-vscode/.vscode-test.js
+++ b/patched-vscode/.vscode-test.js
@@ -45,6 +45,11 @@ const extensions = [
 		label: 'github-authentication',
 		workspaceFolder: path.join(os.tmpdir(), `msft-auth-${Math.floor(Math.random() * 100000)}`),
 		mocha: { timeout: 60_000 }
+	},
+	{
+		label: 'sagemaker-ui-dark-theme',
+		workspaceFolder: `extensions/sagemaker-ui-dark-theme/test-workspace`,
+		mocha: { timeout: 60_000 }
 	}
 ];
 

--- a/patched-vscode/extensions/sagemaker-ui-dark-theme/src/test/extension.test.ts
+++ b/patched-vscode/extensions/sagemaker-ui-dark-theme/src/test/extension.test.ts
@@ -1,0 +1,123 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+const DEFAULT_DARK_MODERN = 'Default Dark Modern';
+const DEFAULT_LIGHT_MODERN = 'Default Light Modern';
+
+async function waitForThemeChange(expectedTheme: string | undefined, timeoutMs: number): Promise<void> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+        const currentTheme = vscode.workspace.getConfiguration('workbench').inspect('colorTheme');
+
+        if (currentTheme?.globalValue === expectedTheme) {
+            return;
+        }
+        await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    throw new Error(`Theme did not change to ${expectedTheme} at the global level within ${timeoutMs}ms`);
+}
+
+suite('SageMaker UI Dark Theme Extension Tests - In SageMaker Unified Studio Environment', () => {
+    // Store original ENV variable value
+    const originalEnv = process.env.SERVICE_NAME;
+
+    suiteSetup(() => {
+        // Clear the theme configurations
+        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Global);
+        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Workspace);
+
+        // Set ENV variable value for SageMaker Unified Studio environment
+        process.env.SERVICE_NAME = 'SageMakerUnifiedStudio';
+    });
+
+    suiteTeardown(() => {
+        // Clear the theme configurations
+        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Global);
+
+        // Restore ENV variable value to original
+        originalEnv ? (process.env.SERVICE_NAME = originalEnv) : delete process.env.SERVICE_NAME;
+    });
+
+    test('Theme is set when global and workspace theme configurations are unset', async () => {
+        // Poll for theme update
+        await waitForThemeChange(DEFAULT_DARK_MODERN, 10000);
+
+        const config = vscode.workspace.getConfiguration();
+        const theme = config.inspect('workbench.colorTheme');
+
+        assert.strictEqual(theme?.globalValue, DEFAULT_DARK_MODERN, `Global theme should be set to ${DEFAULT_DARK_MODERN}`);
+    });
+});
+
+suite('SageMaker UI Dark Theme Extension Tests - In SageMaker Unified Studio Environment', () => {
+    // Store original ENV variable value
+    const originalEnv = process.env.SERVICE_NAME;
+
+    suiteSetup(() => {
+        // Set the global theme configuration to Default Light Modern
+        vscode.workspace.getConfiguration('workbench').update('colorTheme', DEFAULT_LIGHT_MODERN, vscode.ConfigurationTarget.Global);
+        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Workspace);
+
+        // Set ENV variable value for SageMaker Unified Studio environment
+        process.env.SERVICE_NAME = 'SageMakerUnifiedStudio';
+    });
+
+    suiteTeardown(() => {
+        // Clear the theme configurations
+        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Global);
+
+        // Restore ENV variable value to original
+        originalEnv ? (process.env.SERVICE_NAME = originalEnv) : delete process.env.SERVICE_NAME;
+    });
+
+    test('Theme is not set when global theme configuration is set', async () => {
+        // Poll for theme update
+        await waitForThemeChange(DEFAULT_LIGHT_MODERN, 10000);
+
+        // Poll for Default Dark Modern theme update (expected to fail)
+        try {
+            await waitForThemeChange(DEFAULT_DARK_MODERN, 10000);
+            assert.fail(`Global theme should be kept as ${DEFAULT_LIGHT_MODERN}`);
+        } catch (error) {
+            // Expected behavior: Theme should not be set
+        }
+
+        const config = vscode.workspace.getConfiguration();
+        const theme = config.inspect('workbench.colorTheme');
+
+        assert.strictEqual(theme?.globalValue, DEFAULT_LIGHT_MODERN, `Global theme should be kept as ${DEFAULT_LIGHT_MODERN}`);
+    });
+});
+
+suite('SageMaker UI Dark Theme Extension Tests - In SageMaker AI Environment', () => {
+    // Store original ENV variable value
+    const originalEnv = process.env.SERVICE_NAME;
+
+    suiteSetup(() => {
+        // Clear the global theme configuration
+        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Global);
+        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Workspace);
+
+        // Ensure ENV variable value for SageMaker Unified Studio environment is NOT set
+        delete process.env.SERVICE_NAME;
+    });
+
+    suiteTeardown(() => {
+        // Clear the global theme configuration
+        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Global);
+
+        // Restore ENV variable value to original
+        originalEnv ? (process.env.SERVICE_NAME = originalEnv) : delete process.env.SERVICE_NAME;
+    });
+
+    test('Theme is not set', async () => {
+        // Poll for theme update
+        await waitForThemeChange(undefined, 10000);
+
+        const config = vscode.workspace.getConfiguration();
+        const theme = config.inspect('workbench.colorTheme');
+
+        assert.strictEqual(theme?.globalValue, undefined, 'Global theme should not be set');
+    });
+});

--- a/patched-vscode/extensions/sagemaker-ui-dark-theme/src/test/index.ts
+++ b/patched-vscode/extensions/sagemaker-ui-dark-theme/src/test/index.ts
@@ -1,0 +1,33 @@
+import * as path from 'path';
+import * as testRunner from '../../../../test/integration/electron/testrunner';
+
+const options: import('mocha').MochaOptions = {
+    ui: 'tdd',
+    color: true,
+    timeout: 60000
+};
+
+// Set the suite name
+let suite = '';
+if (process.env.VSCODE_BROWSER) {
+    suite = `${process.env.VSCODE_BROWSER} Browser Integration SageMaker UI Dark Theme Tests`;
+} else if (process.env.REMOTE_VSCODE) {
+    suite = 'Remote Integration SageMaker UI Dark Theme Tests';
+} else {
+    suite = 'Integration SageMaker UI Dark Theme Tests';
+}
+
+if (process.env.BUILD_ARTIFACTSTAGINGDIRECTORY) {
+    options.reporter = 'mocha-multi-reporters';
+    options.reporterOptions = {
+        reporterEnabled: 'spec, mocha-junit-reporter',
+        mochaJunitReporterReporterOptions: {
+            testsuitesTitle: `${suite} ${process.platform}`,
+            mochaFile: path.join(process.env.BUILD_ARTIFACTSTAGINGDIRECTORY, `test-results/${process.platform}-${process.arch}-${suite.toLowerCase().replace(/[^\w]/g, '-')}-results.xml`)
+        }
+    };
+}
+
+testRunner.configure(options);
+
+export = testRunner;

--- a/patches/sagemaker-ui-dark-theme.patch
+++ b/patches/sagemaker-ui-dark-theme.patch
@@ -236,3 +236,185 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-ui-dark-theme/package.j
 +  "repository": {
 +  }
 +}
+Index: sagemaker-code-editor/vscode/.vscode-test.js
+===================================================================
+--- sagemaker-code-editor.orig/vscode/.vscode-test.js
++++ sagemaker-code-editor/vscode/.vscode-test.js
+@@ -45,6 +45,11 @@ const extensions = [
+ 		label: 'github-authentication',
+ 		workspaceFolder: path.join(os.tmpdir(), `msft-auth-${Math.floor(Math.random() * 100000)}`),
+ 		mocha: { timeout: 60_000 }
++	},
++	{
++		label: 'sagemaker-ui-dark-theme',
++		workspaceFolder: `extensions/sagemaker-ui-dark-theme/test-workspace`,
++		mocha: { timeout: 60_000 }
+ 	}
+ ];
+ 
+Index: sagemaker-code-editor/vscode/extensions/sagemaker-ui-dark-theme/src/test/extension.test.ts
+===================================================================
+--- /dev/null
++++ sagemaker-code-editor/vscode/extensions/sagemaker-ui-dark-theme/src/test/extension.test.ts
+@@ -0,0 +1,123 @@
++import * as assert from 'assert';
++import * as vscode from 'vscode';
++
++const DEFAULT_DARK_MODERN = 'Default Dark Modern';
++const DEFAULT_LIGHT_MODERN = 'Default Light Modern';
++
++async function waitForThemeChange(expectedTheme: string | undefined, timeoutMs: number): Promise<void> {
++    const startTime = Date.now();
++
++    while (Date.now() - startTime < timeoutMs) {
++        const currentTheme = vscode.workspace.getConfiguration('workbench').inspect('colorTheme');
++
++        if (currentTheme?.globalValue === expectedTheme) {
++            return;
++        }
++        await new Promise(resolve => setTimeout(resolve, 100));
++    }
++    throw new Error(`Theme did not change to ${expectedTheme} at the global level within ${timeoutMs}ms`);
++}
++
++suite('SageMaker UI Dark Theme Extension Tests - In SageMaker Unified Studio Environment', () => {
++    // Store original ENV variable value
++    const originalEnv = process.env.SERVICE_NAME;
++
++    suiteSetup(() => {
++        // Clear the theme configurations
++        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Global);
++        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Workspace);
++
++        // Set ENV variable value for SageMaker Unified Studio environment
++        process.env.SERVICE_NAME = 'SageMakerUnifiedStudio';
++    });
++
++    suiteTeardown(() => {
++        // Clear the theme configurations
++        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Global);
++
++        // Restore ENV variable value to original
++        originalEnv ? (process.env.SERVICE_NAME = originalEnv) : delete process.env.SERVICE_NAME;
++    });
++
++    test('Theme is set when global and workspace theme configurations are unset', async () => {
++        // Poll for theme update
++        await waitForThemeChange(DEFAULT_DARK_MODERN, 10000);
++
++        const config = vscode.workspace.getConfiguration();
++        const theme = config.inspect('workbench.colorTheme');
++
++        assert.strictEqual(theme?.globalValue, DEFAULT_DARK_MODERN, `Global theme should be set to ${DEFAULT_DARK_MODERN}`);
++    });
++});
++
++suite('SageMaker UI Dark Theme Extension Tests - In SageMaker Unified Studio Environment', () => {
++    // Store original ENV variable value
++    const originalEnv = process.env.SERVICE_NAME;
++
++    suiteSetup(() => {
++        // Set the global theme configuration to Default Light Modern
++        vscode.workspace.getConfiguration('workbench').update('colorTheme', DEFAULT_LIGHT_MODERN, vscode.ConfigurationTarget.Global);
++        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Workspace);
++
++        // Set ENV variable value for SageMaker Unified Studio environment
++        process.env.SERVICE_NAME = 'SageMakerUnifiedStudio';
++    });
++
++    suiteTeardown(() => {
++        // Clear the theme configurations
++        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Global);
++
++        // Restore ENV variable value to original
++        originalEnv ? (process.env.SERVICE_NAME = originalEnv) : delete process.env.SERVICE_NAME;
++    });
++
++    test('Theme is not set when global theme configuration is set', async () => {
++        // Poll for theme update
++        await waitForThemeChange(DEFAULT_LIGHT_MODERN, 10000);
++
++        // Poll for Default Dark Modern theme update (expected to fail)
++        try {
++            await waitForThemeChange(DEFAULT_DARK_MODERN, 10000);
++            assert.fail(`Global theme should be kept as ${DEFAULT_LIGHT_MODERN}`);
++        } catch (error) {
++            // Expected behavior: Theme should not be set
++        }
++
++        const config = vscode.workspace.getConfiguration();
++        const theme = config.inspect('workbench.colorTheme');
++
++        assert.strictEqual(theme?.globalValue, DEFAULT_LIGHT_MODERN, `Global theme should be kept as ${DEFAULT_LIGHT_MODERN}`);
++    });
++});
++
++suite('SageMaker UI Dark Theme Extension Tests - In SageMaker AI Environment', () => {
++    // Store original ENV variable value
++    const originalEnv = process.env.SERVICE_NAME;
++
++    suiteSetup(() => {
++        // Clear the global theme configuration
++        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Global);
++        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Workspace);
++
++        // Ensure ENV variable value for SageMaker Unified Studio environment is NOT set
++        delete process.env.SERVICE_NAME;
++    });
++
++    suiteTeardown(() => {
++        // Clear the global theme configuration
++        vscode.workspace.getConfiguration('workbench').update('colorTheme', undefined, vscode.ConfigurationTarget.Global);
++
++        // Restore ENV variable value to original
++        originalEnv ? (process.env.SERVICE_NAME = originalEnv) : delete process.env.SERVICE_NAME;
++    });
++
++    test('Theme is not set', async () => {
++        // Poll for theme update
++        await waitForThemeChange(undefined, 10000);
++
++        const config = vscode.workspace.getConfiguration();
++        const theme = config.inspect('workbench.colorTheme');
++
++        assert.strictEqual(theme?.globalValue, undefined, 'Global theme should not be set');
++    });
++});
+Index: sagemaker-code-editor/vscode/extensions/sagemaker-ui-dark-theme/src/test/index.ts
+===================================================================
+--- /dev/null
++++ sagemaker-code-editor/vscode/extensions/sagemaker-ui-dark-theme/src/test/index.ts
+@@ -0,0 +1,33 @@
++import * as path from 'path';
++import * as testRunner from '../../../../test/integration/electron/testrunner';
++
++const options: import('mocha').MochaOptions = {
++    ui: 'tdd',
++    color: true,
++    timeout: 60000
++};
++
++// Set the suite name
++let suite = '';
++if (process.env.VSCODE_BROWSER) {
++    suite = `${process.env.VSCODE_BROWSER} Browser Integration SageMaker UI Dark Theme Tests`;
++} else if (process.env.REMOTE_VSCODE) {
++    suite = 'Remote Integration SageMaker UI Dark Theme Tests';
++} else {
++    suite = 'Integration SageMaker UI Dark Theme Tests';
++}
++
++if (process.env.BUILD_ARTIFACTSTAGINGDIRECTORY) {
++    options.reporter = 'mocha-multi-reporters';
++    options.reporterOptions = {
++        reporterEnabled: 'spec, mocha-junit-reporter',
++        mochaJunitReporterReporterOptions: {
++            testsuitesTitle: `${suite} ${process.platform}`,
++            mochaFile: path.join(process.env.BUILD_ARTIFACTSTAGINGDIRECTORY, `test-results/${process.platform}-${process.arch}-${suite.toLowerCase().replace(/[^\w]/g, '-')}-results.xml`)
++        }
++    };
++}
++
++testRunner.configure(options);
++
++export = testRunner;


### PR DESCRIPTION
**Description**

- Adding tests for SageMaker UI Dark Theme extension

**Testing Done**

- Tested locally with `yarn test-extension -l sagemaker-ui-dark-theme`

*Issue #, if available:*
N/A

*Description of changes:*
Described above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
