### PR TITLE
Fix: correct line numbers in open-notebook-extension patch

### DIFF
--- a/patches/sagemaker-open-notebook-extension.patch
+++ b/patches/sagemaker-open-notebook-extension.patch
@@ -162,7 +162,7 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-open-notebook-extension
 ===================================================================
 --- /dev/null
 +++ sagemaker-code-editor/vscode/extensions/sagemaker-open-notebook-extension/src/extension.ts
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,100 @@
 +
 +import * as vscode from 'vscode';
 +import * as https from 'https';


### PR DESCRIPTION
**Description**

Correct line numbers in open-notebook-extension patch. **Motivation**

Previously incorrect line numbers were making the patch changes get cut off when applied. We had been manually fixing it each time.

**Testing**
Applied patches and made sure the diff was correctly applied.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
