### PR TITLE
Fix: Correct line numbers in open-notebook-extension patch.

### DIFF
--- a/patches/sagemaker-open-notebook-extension.patch
+++ b/patches/sagemaker-open-notebook-extension.patch
@@ -162,7 +162,7 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-open-notebook-extension
 ===================================================================
 --- /dev/null
 +++ sagemaker-code-editor/vscode/extensions/sagemaker-open-notebook-extension/src/extension.ts
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,100 @@
 +
 +import * as vscode from 'vscode';
 +import * as https from 'https';


### PR DESCRIPTION
Same as https://github.com/aws/sagemaker-code-editor/pull/122

*Issue #, if available:*
Fixes build. Same as https://github.com/aws/sagemaker-code-editor/pull/122

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
