### PR TITLE
Add patch to support custom extensions marketplace

### DIFF
--- a/patched-vscode/product.json
+++ b/patched-vscode/product.json
@@ -33,15 +33,6 @@
 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/out/vs/workbench/contrib/webview/browser/pre/",
 	"builtInExtensions": [
 	],
-	"extensionsGallery": {
-		"serviceUrl": "https://open-vsx.org/vscode/gallery",
-		"itemUrl": "https://open-vsx.org/vscode/item",
-		"resourceUrlTemplate": "https://open-vsx.org/vscode/unpkg/{publisher}/{name}/{version}/{path}",
-		"controlUrl": "",
-		"recommendationsUrl": "",
-		"nlsBaseUrl": "",
-		"publisherUrl": ""
-	},
 	"linkProtectionTrustedDomains": [
 		"https://open-vsx.org"
 	]

--- a/patched-vscode/src/vs/platform/product/common/product.ts
+++ b/patched-vscode/src/vs/platform/product/common/product.ts
@@ -47,6 +47,27 @@ else if (globalThis._VSCODE_PRODUCT_JSON && globalThis._VSCODE_PACKAGE_JSON) {
 			version: pkg.version
 		});
 	}
+
+	if (env['EXTENSIONS_GALLERY']) {
+		console.log(`Custom extensions gallery detected. Parsing...`);
+		Object.assign(product, {
+			extensionsGallery: JSON.parse(env['EXTENSIONS_GALLERY'])
+		});
+	} else {
+		console.log(`Using default extensions gallery.`);
+		Object.assign(product, {
+			extensionsGallery: (product.extensionsGallery || {
+				serviceUrl: "https://open-vsx.org/vscode/gallery",
+				itemUrl: "https://open-vsx.org/vscode/item",
+				resourceUrlTemplate: "https://open-vsx.org/vscode/unpkg/{publisher}/{name}/{version}/{path}",
+				controlUrl: "",
+				recommendationsUrl: "",
+				nlsBaseUrl: "",
+				publisherUrl: ""
+			})
+		});
+	}
+	console.log(JSON.stringify(product.extensionsGallery, null, 2));
 }
 
 // Web environment or unknown

--- a/patched-vscode/src/vs/server/node/webClientServer.ts
+++ b/patched-vscode/src/vs/server/node/webClientServer.ts
@@ -331,14 +331,7 @@ export class WebClientServer {
 		const productConfiguration = {
 			rootEndpoint: base,
 			embedderIdentifier: 'server-distro',
-			extensionsGallery: this._webExtensionResourceUrlTemplate && this._productService.extensionsGallery ? {
-				...this._productService.extensionsGallery,
-				resourceUrlTemplate: this._webExtensionResourceUrlTemplate.with({
-					scheme: 'http',
-					authority: remoteAuthority,
-					path: `${this._webExtensionRoute}/${this._webExtensionResourceUrlTemplate.authority}${this._webExtensionResourceUrlTemplate.path}`
-				}).toString(true)
-			} : undefined
+			extensionsGallery: this._productService.extensionsGallery,
 		} satisfies Partial<IProductConfiguration>;
 
 		if (!this._environmentService.isBuilt) {

--- a/patches/custom-extensions-marketplace.diff
+++ b/patches/custom-extensions-marketplace.diff
@@ -1,0 +1,136 @@
+Index: sagemaker-code-editor/vscode/src/vs/platform/product/common/product.ts
+===================================================================
+--- sagemaker-code-editor.orig/vscode/src/vs/platform/product/common/product.ts
++++ sagemaker-code-editor/vscode/src/vs/platform/product/common/product.ts
+@@ -47,6 +47,27 @@ else if (globalThis._VSCODE_PRODUCT_JSON
+ 			version: pkg.version
+ 		});
+ 	}
++
++	if (env['EXTENSIONS_GALLERY']) {
++		console.log(`Custom extensions gallery detected. Parsing...`);
++		Object.assign(product, {
++			extensionsGallery: JSON.parse(env['EXTENSIONS_GALLERY'])
++		});
++	} else {
++		console.log(`Using default extensions gallery.`);
++		Object.assign(product, {
++			extensionsGallery: (product.extensionsGallery || {
++				serviceUrl: "https://open-vsx.org/vscode/gallery",
++				itemUrl: "https://open-vsx.org/vscode/item",
++				resourceUrlTemplate: "https://open-vsx.org/vscode/unpkg/{publisher}/{name}/{version}/{path}",
++				controlUrl: "",
++				recommendationsUrl: "",
++				nlsBaseUrl: "",
++				publisherUrl: ""
++			})
++		});
++	}
++	console.log(JSON.stringify(product.extensionsGallery, null, 2));
+ }
+ 
+ // Web environment or unknown
+Index: sagemaker-code-editor/vscode/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+===================================================================
+--- sagemaker-code-editor.orig/vscode/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
++++ sagemaker-code-editor/vscode/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+@@ -64,6 +64,8 @@ import { ILocalizedString } from 'vs/pla
+ import { registerNavigableContainer } from 'vs/workbench/browser/actions/widgetNavigationCommands';
+ import { MenuWorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
+ import { createActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
++import { IProductService } from 'vs/platform/product/common/productService';
++import { memoize } from 'vs/base/common/decorators';
+ 
+ export const DefaultViewsContext = new RawContextKey<boolean>('defaultExtensionViews', true);
+ export const ExtensionsSortByContext = new RawContextKey<string>('extensionsSortByValue', '');
+@@ -87,7 +89,6 @@ const SortByUpdateDateContext = new RawC
+ const REMOTE_CATEGORY: ILocalizedString = localize2({ key: 'remote', comment: ['Remote as in remote machine'] }, "Remote");
+ 
+ export class ExtensionsViewletViewsContribution extends Disposable implements IWorkbenchContribution {
+-
+ 	private readonly container: ViewContainer;
+ 
+ 	constructor(
+@@ -516,7 +517,8 @@ export class ExtensionsViewPaneContainer
+ 		@IExtensionService extensionService: IExtensionService,
+ 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
+ 		@IPreferencesService private readonly preferencesService: IPreferencesService,
+-		@ICommandService private readonly commandService: ICommandService
++		@ICommandService private readonly commandService: ICommandService,
++		@IProductService private readonly productService: IProductService,
+ 	) {
+ 		super(VIEWLET_ID, { mergeViewWithContainerWhenSingleView: true }, instantiationService, configurationService, layoutService, contextMenuService, telemetryService, extensionService, themeService, storageService, contextService, viewDescriptorService);
+ 
+@@ -544,6 +546,15 @@ export class ExtensionsViewPaneContainer
+ 		this.searchViewletState = this.getMemento(StorageScope.WORKSPACE, StorageTarget.MACHINE);
+ 	}
+ 
++	@memoize
++	get extensionsGalleryHostname(): string {
++		if (this.productService.extensionsGallery?.serviceUrl) {
++			return new URL(this.productService.extensionsGallery?.serviceUrl).hostname;
++		}
++
++		return 'Marketplace';
++	}
++
+ 	get searchValue(): string | undefined {
+ 		return this.searchBox?.getValue();
+ 	}
+@@ -558,8 +569,7 @@ export class ExtensionsViewPaneContainer
+ 		hide(overlay);
+ 
+ 		const header = append(this.root, $('.header'));
+-		const placeholder = localize('searchExtensions', "Search Extensions in Marketplace");
+-
++		const placeholder = localize('searchExtensions', 'Search extensions in {0}', this.extensionsGalleryHostname);
+ 		const searchValue = this.searchViewletState['query.value'] ? this.searchViewletState['query.value'] : '';
+ 
+ 		const searchContainer = append(header, $('.extensions-search-container'));
+@@ -924,4 +934,4 @@ export class MaliciousExtensionChecker i
+ 			}).then(() => undefined);
+ 		}, err => this.logService.error(err));
+ 	}
+-}
++}
+\ No newline at end of file
+Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
+===================================================================
+--- sagemaker-code-editor.orig/vscode/src/vs/server/node/webClientServer.ts
++++ sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
+@@ -320,14 +320,7 @@ export class WebClientServer {
+ 		const productConfiguration = {
+ 			rootEndpoint: base,
+ 			embedderIdentifier: 'server-distro',
+-			extensionsGallery: this._webExtensionResourceUrlTemplate && this._productService.extensionsGallery ? {
+-				...this._productService.extensionsGallery,
+-				resourceUrlTemplate: this._webExtensionResourceUrlTemplate.with({
+-					scheme: 'http',
+-					authority: remoteAuthority,
+-					path: `${this._webExtensionRoute}/${this._webExtensionResourceUrlTemplate.authority}${this._webExtensionResourceUrlTemplate.path}`
+-				}).toString(true)
+-			} : undefined
++			extensionsGallery: this._productService.extensionsGallery,
+ 		} satisfies Partial<IProductConfiguration>;
+ 
+ 		if (!this._environmentService.isBuilt) {
+Index: sagemaker-code-editor/vscode/product.json
+===================================================================
+--- sagemaker-code-editor.orig/vscode/product.json
++++ sagemaker-code-editor/vscode/product.json
+@@ -33,15 +33,6 @@
+ 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/out/vs/workbench/contrib/webview/browser/pre/",
+ 	"builtInExtensions": [
+ 	],
+-	"extensionsGallery": {
+-		"serviceUrl": "https://open-vsx.org/vscode/gallery",
+-		"itemUrl": "https://open-vsx.org/vscode/item",
+-		"resourceUrlTemplate": "https://open-vsx.org/vscode/unpkg/{publisher}/{name}/{version}/{path}",
+-		"controlUrl": "",
+-		"recommendationsUrl": "",
+-		"nlsBaseUrl": "",
+-		"publisherUrl": ""
+-	},
+ 	"linkProtectionTrustedDomains": [
+ 		"https://open-vsx.org"
+ 	]

--- a/patches/series
+++ b/patches/series
@@ -18,3 +18,4 @@ sagemaker-extension-smus-support.patch
 post-startup-notifications.patch
 sagemaker-extensions-sync.patch
 display-language.patch
+custom-extensions-marketplace.diff


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Add patch to support custom extensions marketplace
* Tested as custom image in SageMaker CodeEditor and verified
  * Env variable EXTENSIONS_GALLERY is set. Tested custom extensions marketplace, proving that custom extensions marketplace is working.
  * Env variable EXTENSIONS_GALLERY is NOT set. Tested default extensions marketplace, proving that the new patch to sagemaker-code-editor doesn’t break anything in extensions marketplace.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.