### PR TITLE
Security patch: Fix CVEs in sagemaker-code-editor v1.6.3

### DIFF
--- a/patched-vscode/yarn.lock
+++ b/patched-vscode/yarn.lock
@@ -4732,9 +4732,9 @@ form-data@^3.0.0:
     mime-types "^2.1.12"
 
 form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -10665,9 +10665,9 @@ write@1.0.3:
     mkdirp "^0.5.1"
 
 ws@^7.2.0:
-  version "7.4.6"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
-  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
 xml2js@^0.4.19:
   version "0.4.23"


### PR DESCRIPTION
## Security Fixes for v1.6.3

This PR addresses **2 critical/high severity CVEs** in sagemaker-code-editor v1.6:

### 🔒 **Fixed Vulnerabilities:**

1. **CVE-2025-7783** (CRITICAL) - **form-data**
   - ✅ **4.0.0 → 4.0.4**

2. **CVE-2024-37890** (HIGH) - **ws** 
   - ✅ **7.4.6 → 8.17.1**

### 📦 **Changes:**
- Updated vulnerable packages in yarn.lock files
- Built and tested code-editor1.6.3.tar.gz successfully

**Related Ticket:** P248382975