### PR TITLE
Fix: Move checkTerminalActivity to server side

### DIFF
--- a/patched-vscode/extensions/sagemaker-idle-extension/src/extension.ts
+++ b/patched-vscode/extensions/sagemaker-idle-extension/src/extension.ts
@@ -2,22 +2,14 @@ import * as vscode from "vscode";
 import * as fs from "fs";
 import * as path from "path";
 
-let idleFilePath: string
-let terminalActivityInterval: NodeJS.Timeout | undefined
-const LOG_PREFIX = "[sagemaker-idle-extension]"
-const CHECK_INTERVAL = 60000; // 60 seconds interval
+let idleFilePath: string;
 
 export function activate(context: vscode.ExtensionContext) {
 	initializeIdleFilePath();
 	registerEventListeners(context);
-	startMonitoringTerminalActivity();
 }
 
-export function deactivate() {
-	if(terminalActivityInterval) {
-		clearInterval(terminalActivityInterval)
-	}
-}
+export function deactivate() {}
 
 /**
  * Initializes the file path where the idle timestamp will be stored.
@@ -28,7 +20,7 @@ function initializeIdleFilePath() {
 	idleFilePath = path.join(tmpDirectory, ".sagemaker-last-active-timestamp");
 
 	// Set initial lastActivetimestamp
-	updateLastActivityTimestamp()
+	updateLastActivityTimestamp();
 }
 
 /**
@@ -55,52 +47,6 @@ function registerEventListeners(context: vscode.ExtensionContext) {
 		})
 	);
 }
-
-/**
- * Starts monitoring terminal activity by setting an interval to check for activity in the /dev/pts directory.
- */
-const startMonitoringTerminalActivity = () => {
-	terminalActivityInterval = setInterval(checkTerminalActivity, CHECK_INTERVAL);
-};
-
-
-/**
- * Checks for terminal activity by reading the /dev/pts directory and comparing modification times of the files.
- *
- * The /dev/pts directory is used in Unix-like operating systems to represent pseudo-terminal (PTY) devices.
- * Each active terminal session is assigned a PTY device. These devices are represented as files within the /dev/pts directory.
- * When a terminal session has activity, such as when a user inputs commands or output is written to the terminal,
- * the modification time (mtime) of the corresponding PTY device file is updated. By monitoring the modification
- * times of the files in the /dev/pts directory, we can detect terminal activity.
- *
- * If activity is detected (i.e., if any PTY device file was modified within the CHECK_INTERVAL), this function
- * updates the last activity timestamp.
- */
-const checkTerminalActivity = () => {
-	fs.readdir("/dev/pts", (err, files) => {
-		if (err) {
-			console.error(`${LOG_PREFIX} Error reading /dev/pts directory:`, err);
-			return;
-		}
-
-		const now = Date.now();
-		const activityDetected = files.some((file) => {
-			const filePath = path.join("/dev/pts", file);
-			try {
-				const stats = fs.statSync(filePath);
-				const mtime = new Date(stats.mtime).getTime();
-				return now - mtime < CHECK_INTERVAL;
-			} catch (error) {
-				console.error(`${LOG_PREFIX} Error reading file stats:`, error);
-				return false;
-			}
-		});
-
-		if (activityDetected) {
-			updateLastActivityTimestamp();
-		}
-	});
-};
 
 /**
  * Updates the last activity timestamp by recording the current timestamp in the idle file and

--- a/patched-vscode/src/vs/server/node/webClientServer.ts
+++ b/patched-vscode/src/vs/server/node/webClientServer.ts
@@ -6,7 +6,6 @@
 import { createReadStream, existsSync, writeFileSync } from 'fs';
 import {readFile } from 'fs/promises';
 import { Promises } from 'vs/base/node/pfs';
-import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as http from 'http';
@@ -99,7 +98,46 @@ export async function serveFile(filePath: string, cacheControl: CacheControl, lo
 	}
 }
 
+const CHECK_INTERVAL = 60000; // 60 seconds interval
 const APP_ROOT = dirname(FileAccess.asFileUri('').fsPath);
+
+/**
+ * Checks for terminal activity by reading the /dev/pts directory and comparing modification times of the files.
+ *
+ * The /dev/pts directory is used in Unix-like operating systems to represent pseudo-terminal (PTY) devices.
+ * Each active terminal session is assigned a PTY device. These devices are represented as files within the /dev/pts directory.
+ * When a terminal session has activity, such as when a user inputs commands or output is written to the terminal,
+ * the modification time (mtime) of the corresponding PTY device file is updated. By monitoring the modification
+ * times of the files in the /dev/pts directory, we can detect terminal activity.
+ *
+ * If activity is detected (i.e., if any PTY device file was modified within the CHECK_INTERVAL), this function
+ * updates the last activity timestamp.
+ */
+const checkTerminalActivity = (idleFilePath: string) => {
+	fs.readdir('/dev/pts', (err, files) => {
+		if (err) {
+			console.error('Error reading /dev/pts directory:', err);
+			return;
+		}
+
+		const now = new Date();
+		const activityDetected = files.some((file) => {
+			const filePath = path.join('/dev/pts', file);
+			try {
+				const stats = fs.statSync(filePath);
+				const mtime = new Date(stats.mtime).getTime();
+				return now.getTime() - mtime < CHECK_INTERVAL;
+			} catch (error) {
+				console.error('Error reading file stats:', error);
+				return false;
+			}
+		});
+
+		if (activityDetected) {
+			fs.writeFileSync(idleFilePath, now.toISOString());
+		}
+	});
+};
 
 export class WebClientServer {
 
@@ -480,6 +518,8 @@ export class WebClientServer {
 				const timestamp = new Date().toISOString();
 				writeFileSync(idleFilePath, timestamp);
 			}
+
+			checkTerminalActivity(idleFilePath);
 
 			const data = await readFile(idleFilePath, 'utf8');
 

--- a/patched-vscode/src/vs/server/node/webClientServer.ts
+++ b/patched-vscode/src/vs/server/node/webClientServer.ts
@@ -114,31 +114,25 @@ const APP_ROOT = dirname(FileAccess.asFileUri('').fsPath);
  * If activity is detected (i.e., if any PTY device file was modified within the CHECK_INTERVAL), this function
  * updates the last activity timestamp.
  */
-const checkTerminalActivity = (idleFilePath: string) => {
-	fs.readdir('/dev/pts', (err, files) => {
-		if (err) {
-			console.error('Error reading /dev/pts directory:', err);
-			return;
-		}
-
+function checkTerminalActivity(idleFilePath: string) {
+	try {
+		const files: string[] = fs.readdirSync('/dev/pts');
 		const now = new Date();
-		const activityDetected = files.some((file) => {
+
+		const activityDetected = files.some((file: string) => {
 			const filePath = path.join('/dev/pts', file);
-			try {
-				const stats = fs.statSync(filePath);
-				const mtime = new Date(stats.mtime).getTime();
-				return now.getTime() - mtime < CHECK_INTERVAL;
-			} catch (error) {
-				console.error('Error reading file stats:', error);
-				return false;
-			}
+			const stats = fs.statSync(filePath);
+			const mtime = new Date(stats.mtime).getTime();
+			return now.getTime() - mtime < CHECK_INTERVAL;
 		});
 
 		if (activityDetected) {
 			fs.writeFileSync(idleFilePath, now.toISOString());
 		}
-	});
-};
+	} catch (err) {
+		console.error('Error checking terminal activity:', err);
+	}
+}
 
 export class WebClientServer {
 

--- a/patched-vscode/src/vs/server/node/webClientServer.ts
+++ b/patched-vscode/src/vs/server/node/webClientServer.ts
@@ -6,6 +6,7 @@
 import { createReadStream, existsSync, writeFileSync } from 'fs';
 import {readFile } from 'fs/promises';
 import { Promises } from 'vs/base/node/pfs';
+import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as http from 'http';

--- a/patches/custom-extensions-marketplace.diff
+++ b/patches/custom-extensions-marketplace.diff
@@ -98,7 +98,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- sagemaker-code-editor.orig/vscode/src/vs/server/node/webClientServer.ts
 +++ sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
-@@ -370,14 +370,7 @@ export class WebClientServer {
+@@ -364,14 +364,7 @@ export class WebClientServer {
  		const productConfiguration = {
  			rootEndpoint: base,
  			embedderIdentifier: 'server-distro',

--- a/patches/custom-extensions-marketplace.diff
+++ b/patches/custom-extensions-marketplace.diff
@@ -98,7 +98,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- sagemaker-code-editor.orig/vscode/src/vs/server/node/webClientServer.ts
 +++ sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
-@@ -331,14 +331,7 @@ export class WebClientServer {
+@@ -370,14 +370,7 @@ export class WebClientServer {
  		const productConfiguration = {
  			rootEndpoint: base,
  			embedderIdentifier: 'server-distro',

--- a/patches/display-language.patch
+++ b/patches/display-language.patch
@@ -304,7 +304,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  import { CharCode } from 'vs/base/common/charCode';
  import { IExtensionManifest } from 'vs/platform/extensions/common/extensions';
  
-@@ -362,6 +363,8 @@ export class WebClientServer {
+@@ -395,6 +396,8 @@ export class WebClientServer {
  			callbackRoute: this._callbackRoute
  		};
  
@@ -313,7 +313,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  		const nlsBaseUrl = this._productService.extensionsGallery?.nlsBaseUrl;
  		const values: { [key: string]: string } = {
  			WORKBENCH_WEB_CONFIGURATION: asJSON(workbenchWebConfiguration),
-@@ -370,6 +373,7 @@ export class WebClientServer {
+@@ -403,6 +406,7 @@ export class WebClientServer {
  			WORKBENCH_NLS_BASE_URL: vscodeBase + (nlsBaseUrl ? `${nlsBaseUrl}${!nlsBaseUrl.endsWith('/') ? '/' : ''}${this._productService.commit}/${this._productService.version}/` : ''),
  			BASE: base,
  			VS_BASE: vscodeBase,
@@ -321,7 +321,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  		};
  
  		if (useTestResolver) {
-@@ -401,7 +405,7 @@ export class WebClientServer {
+@@ -434,7 +438,7 @@ export class WebClientServer {
  			`frame-src 'self' https://*.vscode-cdn.net data:;`,
  			'worker-src \'self\' data: blob:;',
  			'style-src \'self\' \'unsafe-inline\';',

--- a/patches/sagemaker-extensions-sync.patch
+++ b/patches/sagemaker-extensions-sync.patch
@@ -9,7 +9,7 @@ Index: sagemaker-code-editor/vscode/build/gulpfile.extensions.js
 +	'extensions/sagemaker-extensions-sync/tsconfig.json',
  	'extensions/sagemaker-terminal-crash-mitigation/tsconfig.json',
  	'extensions/sagemaker-open-notebook-extension/tsconfig.json',
- 	'extensions/tunnel-forwarding/tsconfig.json',
+ 	'extensions/sagemaker-ui-dark-theme/tsconfig.json',
 Index: sagemaker-code-editor/vscode/build/npm/dirs.js
 ===================================================================
 --- sagemaker-code-editor.orig/vscode/build/npm/dirs.js

--- a/patches/sagemaker-idle-extension.patch
+++ b/patches/sagemaker-idle-extension.patch
@@ -147,27 +147,19 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-idle-extension/src/exte
 ===================================================================
 --- /dev/null
 +++ sagemaker-code-editor/vscode/extensions/sagemaker-idle-extension/src/extension.ts
-@@ -0,0 +1,112 @@
+@@ -0,0 +1,58 @@
 +import * as vscode from "vscode";
 +import * as fs from "fs";
 +import * as path from "path";
 +
-+let idleFilePath: string
-+let terminalActivityInterval: NodeJS.Timeout | undefined
-+const LOG_PREFIX = "[sagemaker-idle-extension]"
-+const CHECK_INTERVAL = 60000; // 60 seconds interval
++let idleFilePath: string;
 +
 +export function activate(context: vscode.ExtensionContext) {
 +	initializeIdleFilePath();
 +	registerEventListeners(context);
-+	startMonitoringTerminalActivity();
 +}
 +
-+export function deactivate() {
-+	if(terminalActivityInterval) {
-+		clearInterval(terminalActivityInterval)
-+	}
-+}
++export function deactivate() {}
 +
 +/**
 + * Initializes the file path where the idle timestamp will be stored.
@@ -178,7 +170,7 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-idle-extension/src/exte
 +	idleFilePath = path.join(tmpDirectory, ".sagemaker-last-active-timestamp");
 +
 +	// Set initial lastActivetimestamp
-+	updateLastActivityTimestamp()
++	updateLastActivityTimestamp();
 +}
 +
 +/**
@@ -205,52 +197,6 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-idle-extension/src/exte
 +		})
 +	);
 +}
-+
-+/**
-+ * Starts monitoring terminal activity by setting an interval to check for activity in the /dev/pts directory.
-+ */
-+const startMonitoringTerminalActivity = () => {
-+	terminalActivityInterval = setInterval(checkTerminalActivity, CHECK_INTERVAL);
-+};
-+
-+
-+/**
-+ * Checks for terminal activity by reading the /dev/pts directory and comparing modification times of the files.
-+ *
-+ * The /dev/pts directory is used in Unix-like operating systems to represent pseudo-terminal (PTY) devices.
-+ * Each active terminal session is assigned a PTY device. These devices are represented as files within the /dev/pts directory.
-+ * When a terminal session has activity, such as when a user inputs commands or output is written to the terminal,
-+ * the modification time (mtime) of the corresponding PTY device file is updated. By monitoring the modification
-+ * times of the files in the /dev/pts directory, we can detect terminal activity.
-+ *
-+ * If activity is detected (i.e., if any PTY device file was modified within the CHECK_INTERVAL), this function
-+ * updates the last activity timestamp.
-+ */
-+const checkTerminalActivity = () => {
-+	fs.readdir("/dev/pts", (err, files) => {
-+		if (err) {
-+			console.error(`${LOG_PREFIX} Error reading /dev/pts directory:`, err);
-+			return;
-+		}
-+
-+		const now = Date.now();
-+		const activityDetected = files.some((file) => {
-+			const filePath = path.join("/dev/pts", file);
-+			try {
-+				const stats = fs.statSync(filePath);
-+				const mtime = new Date(stats.mtime).getTime();
-+				return now - mtime < CHECK_INTERVAL;
-+			} catch (error) {
-+				console.error(`${LOG_PREFIX} Error reading file stats:`, error);
-+				return false;
-+			}
-+		});
-+
-+		if (activityDetected) {
-+			updateLastActivityTimestamp();
-+		}
-+	});
-+};
 +
 +/**
 + * Updates the last activity timestamp by recording the current timestamp in the idle file and
@@ -289,7 +235,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- sagemaker-code-editor.orig/vscode/src/vs/server/node/webClientServer.ts
 +++ sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
-@@ -3,7 +3,8 @@
+@@ -3,8 +3,10 @@
   *  Licensed under the MIT License. See License.txt in the project root for license information.
   *--------------------------------------------------------------------------------------------*/
  
@@ -297,9 +243,59 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
 +import { createReadStream, existsSync, writeFileSync } from 'fs';
 +import {readFile } from 'fs/promises';
  import { Promises } from 'vs/base/node/pfs';
++import * as fs from 'fs';
  import * as path from 'path';
  import * as http from 'http';
-@@ -100,6 +101,7 @@ export class WebClientServer {
+ import * as url from 'url';
+@@ -91,8 +93,47 @@ export async function serveFile(filePath
+ 	}
+ }
+ 
++const CHECK_INTERVAL = 60000; // 60 seconds interval
+ const APP_ROOT = dirname(FileAccess.asFileUri('').fsPath);
+ 
++/**
++ * Checks for terminal activity by reading the /dev/pts directory and comparing modification times of the files.
++ *
++ * The /dev/pts directory is used in Unix-like operating systems to represent pseudo-terminal (PTY) devices.
++ * Each active terminal session is assigned a PTY device. These devices are represented as files within the /dev/pts directory.
++ * When a terminal session has activity, such as when a user inputs commands or output is written to the terminal,
++ * the modification time (mtime) of the corresponding PTY device file is updated. By monitoring the modification
++ * times of the files in the /dev/pts directory, we can detect terminal activity.
++ *
++ * If activity is detected (i.e., if any PTY device file was modified within the CHECK_INTERVAL), this function
++ * updates the last activity timestamp.
++ */
++const checkTerminalActivity = (idleFilePath: string) => {
++	fs.readdir('/dev/pts', (err, files) => {
++		if (err) {
++			console.error('Error reading /dev/pts directory:', err);
++			return;
++		}
++
++		const now = new Date();
++		const activityDetected = files.some((file) => {
++			const filePath = path.join('/dev/pts', file);
++			try {
++				const stats = fs.statSync(filePath);
++				const mtime = new Date(stats.mtime).getTime();
++				return now.getTime() - mtime < CHECK_INTERVAL;
++			} catch (error) {
++				console.error('Error reading file stats:', error);
++				return false;
++			}
++		});
++
++		if (activityDetected) {
++			fs.writeFileSync(idleFilePath, now.toISOString());
++		}
++	});
++};
++
+ export class WebClientServer {
+ 
+ 	private readonly _webExtensionResourceUrlTemplate: URI | undefined;
+@@ -100,6 +141,7 @@ export class WebClientServer {
  	private readonly _staticRoute: string;
  	private readonly _callbackRoute: string;
  	private readonly _webExtensionRoute: string;
@@ -307,7 +303,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  
  	constructor(
  		private readonly _connectionToken: ServerConnectionToken,
-@@ -115,6 +117,7 @@ export class WebClientServer {
+@@ -115,6 +157,7 @@ export class WebClientServer {
  		this._staticRoute = `${serverRootPath}/static`;
  		this._callbackRoute = `${serverRootPath}/callback`;
  		this._webExtensionRoute = `${serverRootPath}/web-extension-resource`;
@@ -315,7 +311,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  	}
  
  	/**
-@@ -132,6 +135,9 @@ export class WebClientServer {
+@@ -132,6 +175,9 @@ export class WebClientServer {
  			if (pathname === this._basePath) {
  				return this._handleRoot(req, res, parsedUrl);
  			}
@@ -325,7 +321,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  			if (pathname === this._callbackRoute) {
  				// callback support
  				return this._handleCallback(res);
-@@ -451,6 +457,31 @@ export class WebClientServer {
+@@ -451,6 +497,33 @@ export class WebClientServer {
  		});
  		return void res.end(data);
  	}
@@ -344,6 +340,8 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
 +				const timestamp = new Date().toISOString();
 +				writeFileSync(idleFilePath, timestamp);
 +			}
++
++			checkTerminalActivity(idleFilePath);
 +
 +			const data = await readFile(idleFilePath, 'utf8');
 +

--- a/patches/sagemaker-idle-extension.patch
+++ b/patches/sagemaker-idle-extension.patch
@@ -247,7 +247,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  import * as path from 'path';
  import * as http from 'http';
  import * as url from 'url';
-@@ -91,8 +93,47 @@ export async function serveFile(filePath
+@@ -91,8 +93,41 @@ export async function serveFile(filePath
  	}
  }
  
@@ -266,36 +266,30 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
 + * If activity is detected (i.e., if any PTY device file was modified within the CHECK_INTERVAL), this function
 + * updates the last activity timestamp.
 + */
-+const checkTerminalActivity = (idleFilePath: string) => {
-+	fs.readdir('/dev/pts', (err, files) => {
-+		if (err) {
-+			console.error('Error reading /dev/pts directory:', err);
-+			return;
-+		}
-+
++function checkTerminalActivity(idleFilePath: string) {
++	try {
++		const files: string[] = fs.readdirSync('/dev/pts');
 +		const now = new Date();
-+		const activityDetected = files.some((file) => {
++
++		const activityDetected = files.some((file: string) => {
 +			const filePath = path.join('/dev/pts', file);
-+			try {
-+				const stats = fs.statSync(filePath);
-+				const mtime = new Date(stats.mtime).getTime();
-+				return now.getTime() - mtime < CHECK_INTERVAL;
-+			} catch (error) {
-+				console.error('Error reading file stats:', error);
-+				return false;
-+			}
++			const stats = fs.statSync(filePath);
++			const mtime = new Date(stats.mtime).getTime();
++			return now.getTime() - mtime < CHECK_INTERVAL;
 +		});
 +
 +		if (activityDetected) {
 +			fs.writeFileSync(idleFilePath, now.toISOString());
 +		}
-+	});
-+};
++	} catch (err) {
++		console.error('Error checking terminal activity:', err);
++	}
++}
 +
  export class WebClientServer {
  
  	private readonly _webExtensionResourceUrlTemplate: URI | undefined;
-@@ -100,6 +141,7 @@ export class WebClientServer {
+@@ -100,6 +135,7 @@ export class WebClientServer {
  	private readonly _staticRoute: string;
  	private readonly _callbackRoute: string;
  	private readonly _webExtensionRoute: string;
@@ -303,7 +297,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  
  	constructor(
  		private readonly _connectionToken: ServerConnectionToken,
-@@ -115,6 +157,7 @@ export class WebClientServer {
+@@ -115,6 +151,7 @@ export class WebClientServer {
  		this._staticRoute = `${serverRootPath}/static`;
  		this._callbackRoute = `${serverRootPath}/callback`;
  		this._webExtensionRoute = `${serverRootPath}/web-extension-resource`;
@@ -311,7 +305,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  	}
  
  	/**
-@@ -132,6 +175,9 @@ export class WebClientServer {
+@@ -132,6 +169,9 @@ export class WebClientServer {
  			if (pathname === this._basePath) {
  				return this._handleRoot(req, res, parsedUrl);
  			}
@@ -321,7 +315,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  			if (pathname === this._callbackRoute) {
  				// callback support
  				return this._handleCallback(res);
-@@ -451,6 +497,33 @@ export class WebClientServer {
+@@ -451,6 +491,33 @@ export class WebClientServer {
  		});
  		return void res.end(data);
  	}

--- a/patches/sagemaker-ui-post-startup.patch
+++ b/patches/sagemaker-ui-post-startup.patch
@@ -21,7 +21,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  /**
   * Return an error to the client.
   */
-@@ -142,6 +147,7 @@ export class WebClientServer {
+@@ -136,6 +141,7 @@ export class WebClientServer {
  	private readonly _callbackRoute: string;
  	private readonly _webExtensionRoute: string;
  	private readonly _idleRoute: string;
@@ -29,7 +29,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  
  	constructor(
  		private readonly _connectionToken: ServerConnectionToken,
-@@ -158,6 +164,7 @@ export class WebClientServer {
+@@ -152,6 +158,7 @@ export class WebClientServer {
  		this._callbackRoute = `${serverRootPath}/callback`;
  		this._webExtensionRoute = `${serverRootPath}/web-extension-resource`;
  		this._idleRoute = '/api/idle';
@@ -37,7 +37,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  	}
  
  	/**
-@@ -186,6 +193,9 @@ export class WebClientServer {
+@@ -180,6 +187,9 @@ export class WebClientServer {
  				// extension resource support
  				return this._handleWebExtensionResource(req, res, parsedUrl);
  			}
@@ -47,7 +47,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  
  			return serveError(req, res, 404, 'Not found.');
  		} catch (error) {
-@@ -524,6 +534,41 @@ export class WebClientServer {
+@@ -518,6 +528,41 @@ export class WebClientServer {
  			serveError(req, res, 500, error.message)
  		}
  	}

--- a/patches/sagemaker-ui-post-startup.patch
+++ b/patches/sagemaker-ui-post-startup.patch
@@ -2,7 +2,15 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- sagemaker-code-editor.orig/vscode/src/vs/server/node/webClientServer.ts
 +++ sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
-@@ -40,6 +40,10 @@ const textMimeType: { [ext: string]: str
+@@ -6,6 +6,7 @@
+ import { createReadStream, existsSync, writeFileSync } from 'fs';
+ import {readFile } from 'fs/promises';
+ import { Promises } from 'vs/base/node/pfs';
++import { spawn } from 'child_process';
+ import * as fs from 'fs';
+ import * as path from 'path';
+ import * as http from 'http';
+@@ -40,6 +41,10 @@ const textMimeType: { [ext: string]: str
  	'.svg': 'image/svg+xml',
  };
  
@@ -13,7 +21,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  /**
   * Return an error to the client.
   */
-@@ -142,6 +146,7 @@ export class WebClientServer {
+@@ -142,6 +147,7 @@ export class WebClientServer {
  	private readonly _callbackRoute: string;
  	private readonly _webExtensionRoute: string;
  	private readonly _idleRoute: string;
@@ -21,7 +29,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  
  	constructor(
  		private readonly _connectionToken: ServerConnectionToken,
-@@ -158,6 +163,7 @@ export class WebClientServer {
+@@ -158,6 +164,7 @@ export class WebClientServer {
  		this._callbackRoute = `${serverRootPath}/callback`;
  		this._webExtensionRoute = `${serverRootPath}/web-extension-resource`;
  		this._idleRoute = '/api/idle';
@@ -29,7 +37,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  	}
  
  	/**
-@@ -186,6 +192,9 @@ export class WebClientServer {
+@@ -186,6 +193,9 @@ export class WebClientServer {
  				// extension resource support
  				return this._handleWebExtensionResource(req, res, parsedUrl);
  			}
@@ -39,7 +47,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  
  			return serveError(req, res, 404, 'Not found.');
  		} catch (error) {
-@@ -524,6 +533,41 @@ export class WebClientServer {
+@@ -524,6 +534,41 @@ export class WebClientServer {
  			serveError(req, res, 500, error.message)
  		}
  	}

--- a/patches/sagemaker-ui-post-startup.patch
+++ b/patches/sagemaker-ui-post-startup.patch
@@ -2,16 +2,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- sagemaker-code-editor.orig/vscode/src/vs/server/node/webClientServer.ts
 +++ sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
-@@ -6,6 +6,8 @@
- import { createReadStream, existsSync, writeFileSync } from 'fs';
- import {readFile } from 'fs/promises';
- import { Promises } from 'vs/base/node/pfs';
-+import { spawn } from 'child_process';
-+import * as fs from 'fs';
- import * as path from 'path';
- import * as http from 'http';
- import * as url from 'url';
-@@ -39,6 +41,10 @@ const textMimeType: { [ext: string]: str
+@@ -40,6 +40,10 @@ const textMimeType: { [ext: string]: str
  	'.svg': 'image/svg+xml',
  };
  
@@ -22,7 +13,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  /**
   * Return an error to the client.
   */
-@@ -102,6 +108,7 @@ export class WebClientServer {
+@@ -142,6 +146,7 @@ export class WebClientServer {
  	private readonly _callbackRoute: string;
  	private readonly _webExtensionRoute: string;
  	private readonly _idleRoute: string;
@@ -30,7 +21,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  
  	constructor(
  		private readonly _connectionToken: ServerConnectionToken,
-@@ -118,6 +125,7 @@ export class WebClientServer {
+@@ -158,6 +163,7 @@ export class WebClientServer {
  		this._callbackRoute = `${serverRootPath}/callback`;
  		this._webExtensionRoute = `${serverRootPath}/web-extension-resource`;
  		this._idleRoute = '/api/idle';
@@ -38,7 +29,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  	}
  
  	/**
-@@ -146,6 +154,9 @@ export class WebClientServer {
+@@ -186,6 +192,9 @@ export class WebClientServer {
  				// extension resource support
  				return this._handleWebExtensionResource(req, res, parsedUrl);
  			}
@@ -48,7 +39,7 @@ Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
  
  			return serveError(req, res, 404, 'Not found.');
  		} catch (error) {
-@@ -482,6 +493,41 @@ export class WebClientServer {
+@@ -524,6 +533,41 @@ export class WebClientServer {
  			serveError(req, res, 500, error.message)
  		}
  	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Problem: The `sagemaker-idle-extension` checks if there is an active terminal session by checking for the existence of `/dev/pts` entries in the file system.  However, when the user closes the Code Editor browser tab, the `sagemaker-idle-extension` is deactivated, so even if an active terminal process is still running, the idle shutdown countdown starts.

Solution: We move the `checkTerminalActivity` function to the `/api/idle` handler on the code server side, so that it runs even when the browser tab is closed.  The `/api/idle` endpoint is called by the SageMaker Studio service on a 1-minute interval to determine whether the Code Editor instance is idle or not.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
