### PR TITLE
Rename uploaded artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: yarn-package
+          name: npm-package
           path: sagemaker-code-editor-${{ env.VERSION }}.tar.gz
   # Run end-to-end tests after the build is complete
   run-e2e-tests:


### PR DESCRIPTION
*Description of changes:*
Rename uploaded artifact to `npm-package`.  Even though the VSCode version in `1.5`, `1.6`, and `1.7` uses `yarn`, and `1.8` uses `npm`, we need to use a consistent name for the artifact in the Github build and release workflows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
