### PR TITLE
Update sagemaker-extensions-sync to read from environment variables

### DIFF
--- a/patches/sagemaker-extensions-sync.patch
+++ b/patches/sagemaker-extensions-sync.patch
@@ -150,8 +150,8 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-extensions-sync/src/con
 +++ sagemaker-code-editor/vscode/extensions/sagemaker-extensions-sync/src/constants.ts
 @@ -0,0 +1,21 @@
 +// constants
-+export const PERSISTENT_VOLUME_EXTENSIONS_DIR = "/home/sagemaker-user/sagemaker-code-editor-server-data/extensions";
-+export const IMAGE_EXTENSIONS_DIR = "/opt/amazon/sagemaker/sagemaker-code-editor-server-data/extensions";
++export const PERSISTENT_VOLUME_EXTENSIONS_DIR = process.env.PERSISTENT_VOLUME_EXTENSIONS_DIR || "/home/sagemaker-user/sagemaker-code-editor-server-data/extensions";
++export const IMAGE_EXTENSIONS_DIR = process.env.IMAGE_EXTENSIONS_DIR || "/opt/amazon/sagemaker/sagemaker-code-editor-server-data/extensions";
 +export const LOG_PREFIX = "[sagemaker-extensions-sync]";
 +
 +export class ExtensionInfo {


### PR DESCRIPTION
## Summary
- Update sagemaker-extensions-sync to read from environment variables
- This change enhances configuration flexibility

## Test plan
- Verify that environment variables are properly read
- Confirm functionality with various configuration scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)