### PR TITLE
Remove module type for service worker

### DIFF
--- a/patches/webview.diff
+++ b/patches/webview.diff
@@ -78,6 +78,15 @@ Index: sagemaker-code-editor/vscode/src/vs/workbench/contrib/webview/browser/pre
 
  	<!-- Disable pinch zooming -->
  	<meta name="viewport"
+@@ -238,7 +238,7 @@
+			}
+
+ 			const swPath = encodeURI(`service-worker.js?v=${expectedWorkerVersion}&vscode-resource-base-authority=${searchParams.get('vscode-resource-base-authority')}&remoteAuthority=${searchParams.get('remoteAuthority') ?? ''}`);
+-			navigator.serviceWorker.register(swPath, { type: 'module' })
++			navigator.serviceWorker.register(swPath)
+ 				.then(async registration => {
+ 					/**
+ 					 * @param {MessageEvent} event
 @@ -344,6 +344,12 @@
  
  				const hostname = location.hostname;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updated webview.diff:
- Running into error when opening jupyter notebook on chrome
`Error loading webview: Error: Could not register service workers: TypeError: Failed to register a ServiceWorker for scope`
- Removed module type for service worker which was causing an error due to browser not sending cookies
- Refer to [code-server solution for 1.101.2](https://github.com/coder/code-server/commit/c5c764d78fd069afc2cc43cfa1bff805dd5a169f)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
