### PR TITLE
(bug fix): Skipping sagemaker extension activation for non sagemaker environment

### DIFF
--- a/patched-vscode/extensions/sagemaker-extension/src/extension.ts
+++ b/patched-vscode/extensions/sagemaker-extension/src/extension.ts
@@ -164,6 +164,13 @@ function renderExtensionAutoUpgradeDisabledNotification() {
 
 export function activate(context: vscode.ExtensionContext) {
 
+    // this extension will only activate within a sagemaker app
+	const isSageMakerApp = !!process.env?.SAGEMAKER_APP_TYPE_LOWERCASE;
+	if (!isSageMakerApp) {
+        console.log('Skipping activation of Sagemaker Extension...');
+		return;
+	}
+
     // TODO: log activation of extension
     console.log('Activating Sagemaker Extension...');
 

--- a/patched-vscode/extensions/sagemaker-extensions-sync/src/constants.ts
+++ b/patched-vscode/extensions/sagemaker-extensions-sync/src/constants.ts
@@ -1,6 +1,6 @@
 // constants
-export const PERSISTENT_VOLUME_EXTENSIONS_DIR = "/home/sagemaker-user/sagemaker-code-editor-server-data/extensions";
-export const IMAGE_EXTENSIONS_DIR = "/opt/amazon/sagemaker/sagemaker-code-editor-server-data/extensions";
+export const PERSISTENT_VOLUME_EXTENSIONS_DIR = process.env.PERSISTENT_VOLUME_EXTENSIONS_DIR || "/home/sagemaker-user/sagemaker-code-editor-server-data/extensions";
+export const IMAGE_EXTENSIONS_DIR = process.env.IMAGE_EXTENSIONS_DIR || "/opt/amazon/sagemaker/sagemaker-code-editor-server-data/extensions";
 export const LOG_PREFIX = "[sagemaker-extensions-sync]";
 
 export class ExtensionInfo {

--- a/patched-vscode/extensions/sagemaker-extensions-sync/src/extension.ts
+++ b/patched-vscode/extensions/sagemaker-extensions-sync/src/extension.ts
@@ -19,8 +19,11 @@ export async function activate() {
 	// this extension will only activate within a sagemaker app
 	const isSageMakerApp = !!process.env?.SAGEMAKER_APP_TYPE_LOWERCASE;
 	if (!isSageMakerApp) {
+        console.log('Skipping activation of Sagemaker Extension Sync...');
 		return;
 	}
+
+    console.log('Activating Sagemaker Extension Sync...');
 
 	// get installed extensions. this could be different from pvExtensions b/c vscode sometimes doesn't delete the assets
 	// for an old extension when uninstalling or changing versions

--- a/patches/sagemaker-extension.diff
+++ b/patches/sagemaker-extension.diff
@@ -2,7 +2,7 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-extension/src/extension
 ===================================================================
 --- /dev/null
 +++ sagemaker-code-editor/vscode/extensions/sagemaker-extension/src/extension.ts
-@@ -0,0 +1,172 @@
+@@ -0,0 +1,179 @@
 +import * as vscode from 'vscode';
 +import * as fs from 'fs';
 +import { SessionWarning } from "./sessionWarning";
@@ -160,6 +160,13 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-extension/src/extension
 +
 +export function activate(context: vscode.ExtensionContext) {
 +
++    // this extension will only activate within a sagemaker app
++	const isSageMakerApp = !!process.env?.SAGEMAKER_APP_TYPE_LOWERCASE;
++	if (!isSageMakerApp) {
++        console.log('Skipping activation of Sagemaker Extension...');
++		return;
++	}
++
 +    // TODO: log activation of extension
 +    console.log('Activating Sagemaker Extension...');
 +
@@ -303,14 +310,14 @@ Index: sagemaker-code-editor/vscode/build/gulpfile.extensions.js
 ===================================================================
 --- sagemaker-code-editor.orig/vscode/build/gulpfile.extensions.js
 +++ sagemaker-code-editor/vscode/build/gulpfile.extensions.js
-@@ -63,6 +63,7 @@ const compilations = [
-	'extensions/references-view/tsconfig.json',
-	'extensions/search-result/tsconfig.json',
-	'extensions/simple-browser/tsconfig.json',
+@@ -60,6 +60,7 @@ const compilations = [
+ 	'extensions/references-view/tsconfig.json',
+ 	'extensions/search-result/tsconfig.json',
+ 	'extensions/simple-browser/tsconfig.json',
 +	'extensions/sagemaker-extension/tsconfig.json',
-	'extensions/tunnel-forwarding/tsconfig.json',
-	'extensions/typescript-language-features/test-workspace/tsconfig.json',
-	'extensions/typescript-language-features/web/tsconfig.json',
+ 	'extensions/tunnel-forwarding/tsconfig.json',
+ 	'extensions/typescript-language-features/test-workspace/tsconfig.json',
+ 	'extensions/typescript-language-features/web/tsconfig.json',
 Index: sagemaker-code-editor/vscode/extensions/sagemaker-extension/README.md
 ===================================================================
 --- /dev/null

--- a/patches/sagemaker-extensions-sync.patch
+++ b/patches/sagemaker-extensions-sync.patch
@@ -174,7 +174,7 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-extensions-sync/src/ext
 ===================================================================
 --- /dev/null
 +++ sagemaker-code-editor/vscode/extensions/sagemaker-extensions-sync/src/extension.ts
-@@ -0,0 +1,100 @@
+@@ -0,0 +1,103 @@
 +import * as process from "process";
 +import * as vscode from 'vscode';
 +
@@ -196,8 +196,11 @@ Index: sagemaker-code-editor/vscode/extensions/sagemaker-extensions-sync/src/ext
 +	// this extension will only activate within a sagemaker app
 +	const isSageMakerApp = !!process.env?.SAGEMAKER_APP_TYPE_LOWERCASE;
 +	if (!isSageMakerApp) {
++        console.log('Skipping activation of Sagemaker Extension Sync...');
 +		return;
 +	}
++
++    console.log('Activating Sagemaker Extension Sync...');
 +
 +	// get installed extensions. this could be different from pvExtensions b/c vscode sometimes doesn't delete the assets
 +	// for an old extension when uninstalling or changing versions


### PR DESCRIPTION
(bug fix): Skipping sagemaker extension activation for non sagemaker environment

*Issue #, if available:*

*Description of changes:*
Skipping sagemaker extension activation for non sagemaker environment and added log lines
Tested locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
