### PR TITLE
Add patch to validate referer for vscode-remote-resource API

### DIFF
--- a/patched-vscode/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/patched-vscode/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -139,6 +139,13 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 		if (pathname === '/vscode-remote-resource') {
 			// Handle HTTP requests for resources rendered in the rich client (images, fonts, etc.)
 			// These resources could be files shipped with extensions or even workspace files.
+			if (req.headers.referer && req.headers.host) {
+				const parsedRefererUrl = url.parse(req.headers.referer, true);
+				if (parsedRefererUrl.host !== req.headers.host) {
+					return serveError(req, res, 403, `Forbidden.`);
+				}
+			}
+
 			const desiredPath = parsedUrl.query['path'];
 			if (typeof desiredPath !== 'string') {
 				return serveError(req, res, 400, `Bad request.`);

--- a/patches/series
+++ b/patches/series
@@ -19,3 +19,4 @@ post-startup-notifications.patch
 sagemaker-extensions-sync.patch
 display-language.patch
 custom-extensions-marketplace.diff
+validate-http-request-referer.patch

--- a/patches/validate-http-request-referer.patch
+++ b/patches/validate-http-request-referer.patch
@@ -1,0 +1,18 @@
+Index: sagemaker-code-editor/vscode/src/vs/server/node/remoteExtensionHostAgentServer.ts
+===================================================================
+--- sagemaker-code-editor.orig/vscode/src/vs/server/node/remoteExtensionHostAgentServer.ts
++++ sagemaker-code-editor/vscode/src/vs/server/node/remoteExtensionHostAgentServer.ts
+@@ -139,6 +139,13 @@ class RemoteExtensionHostAgentServer ext
+ 		if (pathname === '/vscode-remote-resource') {
+ 			// Handle HTTP requests for resources rendered in the rich client (images, fonts, etc.)
+ 			// These resources could be files shipped with extensions or even workspace files.
++			if (req.headers.referer && req.headers.host) {
++				const parsedRefererUrl = url.parse(req.headers.referer, true);
++				if (parsedRefererUrl.host !== req.headers.host) {
++					return serveError(req, res, 403, `Forbidden.`);
++				}
++			}
++
+ 			const desiredPath = parsedUrl.query['path'];
+ 			if (typeof desiredPath !== 'string') {
+ 				return serveError(req, res, 400, `Bad request.`);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix a vulnerability in `/vscode-remote-resource` endpoint that allows a `Referer` domain that does not match the `Host` domain to issue a successful request.  Return a `403` if there is a mismatch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
