### PR TITLE
Remove unused delay-shutdown REST endpoint

### DIFF
--- a/patched-vscode/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/patched-vscode/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -124,13 +124,6 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 			return void res.end(this._productService.commit || '');
 		}
 
-		// Delay shutdown
-		if (pathname === '/delay-shutdown') {
-			this._delayShutdown();
-			res.writeHead(200);
-			return void res.end('OK');
-		}
-
 		if (!httpRequestHasValidConnectionToken(this._connectionToken, req, parsedUrl)) {
 			// invalid connection token
 			return serveError(req, res, 403, `Forbidden.`);
@@ -627,18 +620,6 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 			this._logService.info('Last EH closed, shutting down');
 			this.dispose();
 			process.exit(0);
-		}
-	}
-
-	/**
-	 * If the server is in a shutdown timeout, cancel it and start over
-	 */
-	private _delayShutdown(): void {
-		if (this.shutdownTimer) {
-			console.log('Got delay-shutdown request while in shutdown timeout, delaying');
-			this._logService.info('Got delay-shutdown request while in shutdown timeout, delaying');
-			this._cancelShutdown();
-			this._waitThenShutdown();
 		}
 	}
 

--- a/patches/remove-delay-shutdown-endpoint.diff
+++ b/patches/remove-delay-shutdown-endpoint.diff
@@ -1,0 +1,37 @@
+Index: sagemaker-code-editor/vscode/src/vs/server/node/remoteExtensionHostAgentServer.ts
+===================================================================
+--- sagemaker-code-editor.orig/vscode/src/vs/server/node/remoteExtensionHostAgentServer.ts
++++ sagemaker-code-editor/vscode/src/vs/server/node/remoteExtensionHostAgentServer.ts
+@@ -124,13 +124,6 @@ class RemoteExtensionHostAgentServer ext
+ 			return void res.end(this._productService.commit || '');
+ 		}
+ 
+-		// Delay shutdown
+-		if (pathname === '/delay-shutdown') {
+-			this._delayShutdown();
+-			res.writeHead(200);
+-			return void res.end('OK');
+-		}
+-
+ 		if (!httpRequestHasValidConnectionToken(this._connectionToken, req, parsedUrl)) {
+ 			// invalid connection token
+ 			return serveError(req, res, 403, `Forbidden.`);
+@@ -630,18 +623,6 @@ class RemoteExtensionHostAgentServer ext
+ 		}
+ 	}
+ 
+-	/**
+-	 * If the server is in a shutdown timeout, cancel it and start over
+-	 */
+-	private _delayShutdown(): void {
+-		if (this.shutdownTimer) {
+-			console.log('Got delay-shutdown request while in shutdown timeout, delaying');
+-			this._logService.info('Got delay-shutdown request while in shutdown timeout, delaying');
+-			this._cancelShutdown();
+-			this._waitThenShutdown();
+-		}
+-	}
+-
+ 	private _cancelShutdown(): void {
+ 		if (this.shutdownTimer) {
+ 			console.log('Cancelling previous shutdown timeout');

--- a/patches/series
+++ b/patches/series
@@ -23,3 +23,4 @@ display-language.patch
 custom-extensions-marketplace.diff
 validate-http-request-referer.patch
 sanitize-terminal-sendtext-paths.diff
+remove-delay-shutdown-endpoint.diff


### PR DESCRIPTION
*Issue #, if available:*
  * P398067552

*Description of changes:*
  * Remove the `/delay-shutdown` HTTP endpoint and its backing `_delayShutdown()` method from `remoteExtensionHostAgentServer.ts`
  * This feature is not used by the service — the shutdown lifecycle is fully managed by extension host connection events (`_onDidCloseExtHostConnection`)
  * The endpoint was positioned before the connection token validation, meaning it required no authentication
  * After this change, `GET /delay-shutdown` returns 403 (without token) or 404 (with token) instead of 200

*Testing:*
  * Verified all existing patches apply cleanly with the new patch appended (`quilt push -a` succeeds)
  * Confirmed no references to `delay-shutdown` or `_delayShutdown` remain in the patched source
  * Confirmed `_cancelShutdown()` and `_waitThenShutdown()` are preserved (still used by `_onDidCloseExtHostConnection`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.