### PR TITLE
fix(security): Handle multi-token command substitution in sendText sanitizer

### DIFF
--- a/patched-vscode/src/vs/platform/terminal/common/terminalEnvironment.ts
+++ b/patched-vscode/src/vs/platform/terminal/common/terminalEnvironment.ts
@@ -77,7 +77,12 @@ export function sanitizePathsInCommand(text: string): string {
 	// Strip newlines and null bytes to prevent command injection via line splitting
 	let result = text.replace(/[\r\n\x00]/g, ' ');
 
-	// 1. Handle double-quoted paths containing '/' — escape $(), ${}, backticks
+	// 1. Escape complete $(...), ${...}, `...` constructs followed by / (path context)
+	result = result.replace(/(?<!\\)\$\(([^)]*(?:\([^)]*\)[^)]*)*)\)\//g, '\\$($1)/');
+	result = result.replace(/(?<!\\)\$\{([^}]*)\}\//g, '\\${$1}/');
+	result = result.replace(/(?<!\\)`([^`]*)`\//g, '\\`$1\\`/');
+
+	// 2. Handle double-quoted paths containing '/' — escape $(), ${}, backticks
 	result = result.replace(
 		/"((?:[^"\\]|\\.)*\/(?:[^"\\]|\\.)*)"/g,
 		(_match: string, inner: string) => {
@@ -89,7 +94,7 @@ export function sanitizePathsInCommand(text: string): string {
 		}
 	);
 
-	// 2. Handle unquoted path-like tokens (contain '/') — escape $(), ${}, backticks
+	// 3. Handle unquoted path-like tokens (contain '/') — escape $(), ${}, backticks
 	result = result.replace(
 		/(?<=[;\s&|>]|^)([^\s;|&<>]*\/[^\s;|&<>]*)/gm,
 		(pathToken: string) => {

--- a/patches/sanitize-terminal-sendtext-paths.diff
+++ b/patches/sanitize-terminal-sendtext-paths.diff
@@ -1,16 +1,17 @@
 Sanitize path-like segments in terminal sendText to prevent command injection
 
 Broadens sanitization from cd-only paths to all path-like tokens in
-terminal.sendText(). Adds newline/null byte stripping, narrows escaping
-to only command substitution patterns ($(), ${}, backticks), and handles
-double-quoted paths. This prevents injection via malicious folder names
-in any command, not just cd.
+terminal.sendText(). Uses a three-pass approach: (1) escape complete
+$(), ${}, backtick constructs followed by / to handle multi-token
+payloads like $(curl google.com)/test.py, (2) escape patterns inside
+double-quoted paths, (3) escape residual patterns in unquoted path-like
+tokens. Also strips newlines and null bytes to prevent line splitting.
 
 Index: sagemaker-code-editor/vscode/src/vs/platform/terminal/common/terminalEnvironment.ts
 ===================================================================
 --- sagemaker-code-editor.orig/vscode/src/vs/platform/terminal/common/terminalEnvironment.ts
 +++ sagemaker-code-editor/vscode/src/vs/platform/terminal/common/terminalEnvironment.ts
-@@ -68,3 +68,40 @@
+@@ -68,3 +68,45 @@
  export function shouldUseEnvironmentVariableCollection(slc: IShellLaunchConfig): boolean {
  	return !slc.strictEnv;
  }
@@ -23,7 +24,12 @@ Index: sagemaker-code-editor/vscode/src/vs/platform/terminal/common/terminalEnvi
 +	// Strip newlines and null bytes to prevent command injection via line splitting
 +	let result = text.replace(/[\r\n\x00]/g, ' ');
 +
-+	// 1. Handle double-quoted paths containing '/' — escape $(), ${}, backticks
++	// 1. Escape complete $(...), ${...}, `...` constructs followed by / (path context)
++	result = result.replace(/(?<!\\)\$\(([^)]*(?:\([^)]*\)[^)]*)*)\)\//g, '\\$($1)/');
++	result = result.replace(/(?<!\\)\$\{([^}]*)\}\//g, '\\${$1}/');
++	result = result.replace(/(?<!\\)`([^`]*)`\//g, '\\`$1\\`/');
++
++	// 2. Handle double-quoted paths containing '/' — escape $(), ${}, backticks
 +	result = result.replace(
 +		/"((?:[^"\\]|\\.)*\/(?:[^"\\]|\\.)*)"/g,
 +		(_match: string, inner: string) => {
@@ -35,7 +41,7 @@ Index: sagemaker-code-editor/vscode/src/vs/platform/terminal/common/terminalEnvi
 +		}
 +	);
 +
-+	// 2. Handle unquoted path-like tokens (contain '/') — escape $(), ${}, backticks
++	// 3. Handle unquoted path-like tokens (contain '/') — escape $(), ${}, backticks
 +	result = result.replace(
 +		/(?<=[;\s&|>]|^)([^\s;|&<>]*\/[^\s;|&<>]*)/gm,
 +		(pathToken: string) => {


### PR DESCRIPTION
## Problem

The terminal `sendText` sanitizer only escaped `$()` within single whitespace-delimited tokens. Multi-token payloads like `$(curl google.com)/test.py` span two tokens (`$(curl` and `google.com)/test.py`), so the `$(` was never matched and the command substitution executed:

```
/opt/conda/bin/python "/home/sagemaker-user/$(curl google.com)/test.py"
```

## Fix

Adds a first-pass regex that matches **complete** `$(...)`, `${...}`, and backtick constructs (including internal spaces) followed by `/` before per-token processing.

Three-pass approach:
1. Escape complete substitution constructs followed by `/` (handles multi-token payloads)
2. Escape patterns inside double-quoted paths containing `/`
3. Escape residual patterns in unquoted path-like tokens containing `/`

## Testing

- Patch applies cleanly via `sh ./scripts/install.sh`
- Compilation succeeds
- Manually verified: `$(curl google.com)/test.py` → `\$(curl google.com)/test.py`

Related: https://github.com/aws/code-editor/pull/207